### PR TITLE
fix: read Debian version directly from /etc/debian_version

### DIFF
--- a/osversion-check.sh
+++ b/osversion-check.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 #
 # This script checks if the container version matches the latest Debian release.
-# It runs /usr/bin/container-version to get the current version and compares it
+# It reads /etc/debian_version to get the current version and compares it
 # against the latest Debian stable release version fetched via curl.
 # Returns 0 if versions match, non-zero otherwise.
 
-# Get current container version
-CURRENT_VERSION=$(/usr/bin/container-version)
+# Get current Debian version directly from /etc/debian_version
+CURRENT_VERSION=$(cat /etc/debian_version | tr -d '[:space:]')
 if [ -z "$CURRENT_VERSION" ]; then
-  echo "Failed to get current container version"
+  echo "Failed to read Debian version from /etc/debian_version"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Fixes #11

Removes the indirect call to `/usr/bin/container-version` in `osversion-check.sh` and replaces it with a direct read of `/etc/debian_version`.

## Changes

- **`osversion-check.sh`**: Replace `CURRENT_VERSION=$(/usr/bin/container-version)` with `CURRENT_VERSION=$(cat /etc/debian_version | tr -d '[:space:]')`
- Updated inline comment and error message to reflect the new source
- The `tr -d '[:space:]'` strips any trailing newline for clean comparison

## Acceptance Criteria

- [x] `osversion-check.sh` no longer calls `/usr/bin/container-version`
- [x] `CURRENT_VERSION` is read directly from `/etc/debian_version`
- [x] Script exits non-zero with descriptive message if `/etc/debian_version` is missing or empty
- [x] Existing behaviour of the `LATEST_VERSION` curl fetch is unchanged
- [ ] Script exits 0 when running Debian version matches latest stable (runtime validation)
- [ ] The container builds successfully with the updated script (CI)

## Risk

Low — single-file, 4-line change. No functional logic altered; only the version source changes.