### PR TITLE
fix: resolve SC2002 useless cat in osversion-check.sh

### DIFF
--- a/osversion-check.sh
+++ b/osversion-check.sh
@@ -6,7 +6,7 @@
 # Returns 0 if versions match, non-zero otherwise.
 
 # Get current Debian version directly from /etc/debian_version
-CURRENT_VERSION=$(cat /etc/debian_version | tr -d '[:space:]')
+CURRENT_VERSION=$(tr -d '[:space:]' < /etc/debian_version)
 if [ -z "$CURRENT_VERSION" ]; then
   echo "Failed to read Debian version from /etc/debian_version"
   exit 1


### PR DESCRIPTION
## Summary

Fixes #13

Resolves a `shellcheck` SC2002 style violation introduced in PR #12.

## Change

Replace the UUOC (Useless Use of Cat) pattern with input redirection:

```sh
# Before (SC2002 violation):
CURRENT_VERSION=$(cat /etc/debian_version | tr -d '[:space:]')

# After (POSIX-idiomatic):
CURRENT_VERSION=$(tr -d '[:space:]' < /etc/debian_version)
```

## Impact

- **Functional:** None — behaviour is identical
- **Risk:** Low — 1-line change

## Acceptance Criteria

- [x] SC2002 pattern removed
- [x] `shellcheck osversion-check.sh` exits 0
- [ ] CI pipeline passes (lint + build)