### PR TITLE
fix(locale): set LANG and LC_ALL to C.UTF-8 to fix ASCII terminal issue

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -52,6 +52,14 @@ RUN /bin/mkdir -p /etc/container \
  && /bin/ln -fsv "/usr/share/zoneinfo/$(cat /etc/timezone)" /etc/localtime
 
 # ╭――――――――――――――――――――╮
+# │ LOCALE             │
+# ╰――――――――――――――――――――╯
+# Set locale to UTF-8 to avoid terminal falling back to ASCII-only mode.
+# C.UTF-8 is a built-in glibc locale; no additional packages are required.
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# ╭――――――――――――――――――――╮
 # │ VOLUMES            │
 # ╰――――――――――――――――――――╯
 # The volumes section creates the mount points for the most common volume


### PR DESCRIPTION
Closes #16

## Summary
Adds a `LOCALE` section to `Containerfile` setting `ENV LANG=C.UTF-8` and `ENV LC_ALL=C.UTF-8`. `C.UTF-8` is a built-in glibc locale — no additional packages (e.g. `locales`) are required.

## Change
```dockerfile
# ╭――――――――――――――――――――╮
# │ LOCALE             │
# ╰――――――――――――――――――――╯
# Set locale to UTF-8 to avoid terminal falling back to ASCII-only mode.
# C.UTF-8 is a built-in glibc locale; no additional packages are required.
ENV LANG=C.UTF-8
ENV LC_ALL=C.UTF-8
```
Placed after the TIMEZONE section, consistent with the existing Containerfile section style.

## Validation
- `hadolint` passes (DL3008 already suppressed in `.hadolint.yaml`; no new warnings introduced)
- No new packages added
- Existing health, backup, version, and privilege scripts are unaffected