### PR TITLE
fix: skip packages-check when run without root privileges

### DIFF
--- a/packages.sh
+++ b/packages.sh
@@ -7,6 +7,12 @@
 # This script cleans up any temporary cache created during its execution
 # to keep the container image as small as possible.
 
+# Check for root privileges
+if [ "$(id -u)" -ne 0 ]; then
+    echo "packages-check: skipping (requires root)"
+    exit 0
+fi
+
 # Refresh the package index to detect available updates
 if ! apt-get update -qq 2>/dev/null; then
     echo "packages-check: failed to update package index"


### PR DESCRIPTION
## Summary

Fixes #32.

`packages.sh` unconditionally runs `apt-get update`, which requires root. When executed as a non-root user, this fails and marks the container unhealthy even when the container itself is fine.

## Change

Added a POSIX `id -u` privilege check at the start of `packages.sh`. When UID is non-zero (non-root), the script prints an informative message and exits 0. The existing apt-get logic is untouched and runs as before when root.

## AC Status

- [x] [Develop] Privilege check implemented — `id -u` guard added before `apt-get update`
- [x] [Develop] Skip/soft-fail with informative message — prints `packages-check: skipping (requires root)` and exits 0
- [x] [Develop] Documentation — skip message is self-documenting
- [ ] [Integrate] CI build verifies non-root skip — pending CI run
- [ ] [Run] Health suite returns success as non-root — pending CI run
- [ ] [Run] Full verification still works as root — pending CI run

## Risk: low

Single 4-line guard prepended to an existing script. No other files changed (only `.pre-commit-config.yaml` updated by pre-commit hook).

## CI

Pending — branch just pushed.