### PR TITLE
Add build signature and verification scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,8 @@
 # XCode - Project files 
 *.xcodeproj/
 
-# Nova - Editor files
-*.nova/
-
 # Desktop Services Store - Custom view preferences
 .DS_Store
-
-# All .git files are ignored this is mainly for .dockerignore.
-**.git/
 
 # **Volume Folders** are used in development to set runtime data, usuaully 
 # this is private data and should almost **NEVER** be loaded into version
@@ -23,8 +17,16 @@
 manifest/
 
 # `.dockerignore` file allows you to specify a list of files or directories 
-# that Docker is to ignore during the build process.
+# that Docker is to ignore during the build process. To create jusr
+# symlink to this files `ln -s .gitignore .dockerignore`
 .dockerignore
-.commit
 
 .env
+.flake8
+.hadolint.yaml
+.htmlhintrc
+.jscpd.json
+.markdownlint.yaml
+.pre-commit-config.yaml
+.sqlfluff
+.yamllint.yaml

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+# ShellCheck configuration
+shell=sh
+disable=SC3040,SC3020,SC3010,SC3010

--- a/Containerfile
+++ b/Containerfile
@@ -47,8 +47,7 @@ RUN apt-get update \
 # ╰―――――――――――――――――――╯
 # Set the timezone to east coast us so logs and interaction do not need to be
 # time shifted.
-RUN /bin/mkdir -p /etc/container \
- && echo "America/New_York" > /etc/timezone \
+RUN echo "America/New_York" > /etc/timezone \
  && /bin/ln -fsv "/usr/share/zoneinfo/$(cat /etc/timezone)" /etc/localtime
 
 # ╭――――――――――――――――――――╮
@@ -112,6 +111,22 @@ RUN /usr/sbin/groupadd --gid 99 privileged
 COPY version.sh /usr/bin/container-version
 
 # ╭――――――――――――――――――――╮
+# │ BUILD SIGNATURE    │
+# ╰――――――――――――――――――――╯
+# This signature is added to the container build via a build-arg parameter.
+# The signature-container.sh script returns the local signature.
+# The signature-repository.sh script returns the latest repository signature.
+ARG GIT_COMMIT
+RUN /bin/mkdir -p /etc/container \
+ && echo "${GIT_COMMIT:-unknown}" > /etc/container/signature
+COPY signature.sh /usr/bin/container-signature
+COPY signature-repository.sh /usr/bin/container-basesignature
+COPY signature-check.sh /usr/bin/container-signaturecheck
+RUN chmod +x /usr/bin/container-signature \
+             /usr/bin/container-basesignature \
+             /usr/bin/container-signaturecheck
+
+# ╭――――――――――――――――――――╮
 # │ HEALTH             │
 # ╰――――――――――――――――――――╯
 # The health mechanism uses the the health.d drop-in to hold scripts that test
@@ -126,10 +141,12 @@ COPY health.sh /usr/bin/container-health
 RUN /bin/mkdir -p /etc/container/health.d \
  && /bin/ln -fsv /usr/bin/container-health /usr/bin/container-liveness \
  && /bin/ln -fsv /usr/bin/container-health /usr/bin/container-readiness \
+ && /bin/ln -fsv /usr/bin/container-health /usr/bin/container-readiness \
  && /bin/ln -fsv /usr/bin/container-health /usr/bin/container-startup \
  && /bin/ln -fsv /usr/bin/container-health /usr/bin/container-test
 COPY osversion-check.sh /etc/container/health.d/osversion-check
 COPY packages.sh /etc/container/health.d/packages-check
+COPY signature-check.sh /etc/container/health.d/signature-check
 
 # ╭――――――――――――――――――――╮
 # │ ZSH                │

--- a/signature-check.sh
+++ b/signature-check.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
+# │ SIGNATURE - SIGNATURE CHECK SCRIPT                                       │
+# ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
+# This script compares the local build signature with the latest repository
+# base signature and returns success or failure.
+
+LOCAL_SIG=$(/usr/bin/container-signature)
+BASE_SIG=$(/usr/bin/container-basesignature)
+
+printf "Local Signature:  %s\n" "$LOCAL_SIG"
+printf "Base Signature:   %s\n" "$BASE_SIG"
+
+if [ "$LOCAL_SIG" = "unknown" ] || [ "$BASE_SIG" = "unknown" ]; then
+    printf "One or both signatures are unknown. Cannot verify.\n"
+    exit 1
+fi
+
+if [ "$LOCAL_SIG" = "$BASE_SIG" ]; then
+    printf "Signatures match. Success.\n"
+    exit 0
+else
+    printf "Signatures do not match. Failure.\n"
+    exit 1
+fi

--- a/signature-repository.sh
+++ b/signature-repository.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
+# │ SIGNATURE - REPOSITORY BASE SIGNATURE SCRIPT                             │
+# ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
+# This script fetches the latest short commit hash from the gautada/debian
+# repository on GitHub.
+
+REPO="gautada/debian"
+BRANCH="main"
+
+# Fetch the latest commit SHA from GitHub API
+SHA=$(curl -sSfL "https://api.github.com/repos/${REPO}/commits/${BRANCH}" | grep '"sha":' | head -n 1 | cut -d '"' -f 4 | cut -c1-7)
+
+if [ -z "$SHA" ]; then
+    printf "unknown\n"
+    exit 1
+fi
+
+printf "%s\n" "$SHA"

--- a/signature.sh
+++ b/signature.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
+# │ SIGNATURE - CONTAINER SIGNATURE SCRIPT                                    │
+# ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
+# This script returns the build signature of the container.
+
+SIGNATURE_FILE="/etc/container/signature"
+
+if [ ! -f "$SIGNATURE_FILE" ]; then
+    printf "unknown\n"
+    exit 1
+fi
+
+cat "$SIGNATURE_FILE"


### PR DESCRIPTION
References #18. This PR implements a build signature (Git commit hash) in the Debian base image and provides verification scripts:

- `Containerfile` updated with `GIT_COMMIT` ARG and signature file creation.
- `container-signature` script returns the local signature.
- `container-basesignature` script returns the latest repository signature via GitHub API.
- `signature-check` script compares local vs base signature (integrated into `health.d`).