### PR TITLE
Sync container.yaml onto the current cicd distributable template

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [dev, main]
   push:
-    branches: [dev, main]
 
 permissions:
   contents: read
@@ -18,10 +17,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  container:
-    uses: gautada/cicd/.github/workflows/cicd-container.yaml@main
+  enforce-dev-only:
+    name: Only accept promotions from dev
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Reject any PR into main that isn't from dev
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "${HEAD_REF}" != "dev" ]]; then
+            echo "::error::Direct PRs into main are not allowed - merge into dev first, then promote dev to main."
+            exit 1
+          fi
+
+  check-pr:
+    name: Check for an open PR on this branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - name: Skip push runs once a PR is already open for this branch
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          skip=false
+          if [[ "${EVENT_NAME}" == push && "${REF_NAME}" != dev && "${REF_NAME}" != main ]]; then
+            existing="$(gh pr list --head "${REF_NAME}" --state open \
+              --json number --jq '.[0].number // empty')"
+            if [[ -n "${existing}" ]]; then
+              echo "PR #${existing} is already open for ${REF_NAME}; skipping the push-triggered run."
+              skip=true
+            fi
+          fi
+          echo "skip=${skip}" >> "${GITHUB_OUTPUT}"
+
+  base:
+    needs: check-pr
+    if: needs.check-pr.outputs.skip != 'true'
+    uses: gautada/cicd/.github/workflows/cicd-base.yaml@main
     with:
       cicd_ref: main
+
+  container:
+    needs: [check-pr, base]
+    if: needs.check-pr.outputs.skip != 'true'
+    uses: gautada/cicd/.github/workflows/cicd-container.yaml@main
     secrets:
       DOCKERIO_REGISTRY: ${{ secrets.DOCKERIO_REGISTRY }}
       DOCKERIO_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}


### PR DESCRIPTION
debian's .github/workflows/container.yaml was still the pre-redesign version - missing everything built into cicd's templates/workflows/container.yaml this session:

- Feature-branch triggers (bare `push:`, not restricted to `[dev, main]`)
- `enforce-dev-only`: rejects any PR straight into `main` that isn't from `dev`
- `check-pr`: skips a redundant push-triggered run once a PR is already open for that branch
- `base` job (lint + deep-scan via `cicd-base.yaml`) ahead of the container build

Copied `templates/workflows/container.yaml` from `cicd`'s `main` verbatim - no changes to the actual build/publish logic in `cicd-container.yaml` itself. `build-pr` (no publish) vs `build` (publish, gated to `dev`/`main` pushes only) behavior is unchanged.

Verified: valid YAML, both embedded shell scripts pass `bash -n`, no lines over 120 chars.