### PR TITLE
Fix container.yaml: needs contents: write for GitHub Releases

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -8,7 +8,7 @@ on:
   push:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   security-events: write
 


### PR DESCRIPTION
PR #53 merged the synced template before the permissions bug (gautada/cicd#92) was found and fixed - the sync's first CI run failed with:

```
Error calling workflow 'gautada/cicd/.github/workflows/cicd-container.yaml@main'.
The nested job 'github-release' is requesting 'contents: write', but is only allowed 'contents: read'.
```

Pulled the corrected `templates/workflows/container.yaml` from `cicd` (post gautada/cicd#92) - one-line fix, `contents: read` -> `write`.